### PR TITLE
Refresh release pipeline for Go 1.26.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,12 @@ jobs:
 
     name: Setup
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
+    - uses: actions/checkout@v6
+    - uses: actions/setup-go@v6
       if: ${{ matrix.legacy != 'debian9' }}
       with:
         go-version: ${{ env.golang-version }}
+        cache: false
 
     - name: Setup CryptoPro/go
       if: ${{ matrix.legacy != 'debian9' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: Release
-on: push
+on:
+  push:
+  workflow_dispatch:
 
 env:
   golang-version: '1.26.4'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,10 @@ name: Release
 on: push
 
 env:
-  golang-version: '1.22.12'
-  go-cpro-version: 'v1.22.12-msspi-1'
-  nats-server-version: 'v2.10.25'
-  nats-streaming-server-version: 'v0.25.6-20250205'
+  golang-version: '1.26.4'
+  go-cpro-version: 'v1.26.4-msspi-1'
+  nats-server-version: 'v2.12.11'
+  nats-streaming-server-version: 'v0.25.6-20260616'
 
 jobs:
   test:
@@ -30,8 +30,8 @@ jobs:
 
     name: Setup
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
       if: ${{ matrix.legacy != 'debian9' }}
       with:
         go-version: ${{ env.golang-version }}
@@ -63,7 +63,7 @@ jobs:
           - <<'EOF'
         FROM debian:9
 
-        ARG GO_VERSION=1.22.12
+        ARG GO_VERSION=1.26.4
 
         RUN printf '%s\n' \
               'deb http://archive.debian.org/debian stretch main' \
@@ -139,7 +139,7 @@ jobs:
             }
 
             build_project nats-io nats-server "${NATS_SERVER_VERSION}"
-            build_project CryptoPro nats-streaming-server "${NATS_STREAMING_SERVER_VERSION}"
+            build_project PiDmitrius nats-streaming-server "${NATS_STREAMING_SERVER_VERSION}"
           '
 
     - name: Build nats-server
@@ -181,7 +181,7 @@ jobs:
         AEXT: ${{ matrix.aext }}
       shell: bash
       run: |
-        git -c advice.detachedHead=false clone --depth 1 --branch ${PROJECTTAG} https://github.com/CryptoPro/${PROJECTNAME}.git
+        git -c advice.detachedHead=false clone --depth 1 --branch ${PROJECTTAG} https://github.com/PiDmitrius/${PROJECTNAME}.git
         cd ${PROJECTNAME}
         go build -v
         if [ "$RUNNER_OS" == "Windows" ]; then
@@ -203,7 +203,7 @@ jobs:
         fi
 
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ env:
   golang-version: '1.26.4'
   go-cpro-version: 'v1.26.4-msspi-1'
   nats-server-version: 'v2.12.11'
-  nats-streaming-server-version: 'v0.25.6-20260616'
+  nats-streaming-server-version: 'v0.25.6-20260617'
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         if [ "$RUNNER_OS" != "Windows" ]; then
           make -B static-capix
         fi
-        cp -rf $RUNNER_TEMP/go/src $GOROOT
+        cp -rf "$RUNNER_TEMP/go/src" "$(go env GOROOT)"
 
     - name: Build legacy Debian 9 image
       if: ${{ matrix.legacy == 'debian9' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
             }
 
             build_project nats-io nats-server "${NATS_SERVER_VERSION}"
-            build_project PiDmitrius nats-streaming-server "${NATS_STREAMING_SERVER_VERSION}"
+            build_project CryptoPro nats-streaming-server "${NATS_STREAMING_SERVER_VERSION}"
           '
 
     - name: Build nats-server
@@ -183,7 +183,7 @@ jobs:
         AEXT: ${{ matrix.aext }}
       shell: bash
       run: |
-        git -c advice.detachedHead=false clone --depth 1 --branch ${PROJECTTAG} https://github.com/PiDmitrius/${PROJECTNAME}.git
+        git -c advice.detachedHead=false clone --depth 1 --branch ${PROJECTTAG} https://github.com/CryptoPro/${PROJECTNAME}.git
         cd ${PROJECTNAME}
         go build -v
         if [ "$RUNNER_OS" == "Windows" ]; then


### PR DESCRIPTION
## Summary

- update release pipeline to Go 1.26.4 and CryptoPro Go v1.26.4-msspi-1
- build NATS Server v2.12.11 and STAN v0.25.6-20260617
- keep the STAN clone source aligned with the CryptoPro tag
- refresh GitHub Actions setup steps to checkout@v6/setup-go@v6 and disable root go.sum cache lookup

## Validation

- https://github.com/PiDmitrius/nats-msspi/actions/runs/27676131014 succeeded on linux, darwin, win64, and debian9/glibc-2.24
- https://github.com/PiDmitrius/nats-msspi/actions/runs/27676694994 succeeded on linux, darwin, win64, and debian9/glibc-2.24 after workflow action cleanup
