### PR TITLE
Use Node 24 release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,7 @@ jobs:
         fi
 
     - name: Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: |


### PR DESCRIPTION
## Summary

- update `softprops/action-gh-release` from `v2` to `v3`
- remove the remaining Node.js 20 deprecation warning from the tag release path

## Validation

- verified `softprops/action-gh-release@v3` action metadata uses `runs.using: node24`
- checked workflow action references: `checkout@v6`, `setup-go@v6`, `softprops/action-gh-release@v3`

## Notes

The warning only appeared during tag publication because the `Release` step is skipped on non-tag validation runs.
